### PR TITLE
Pull in latk file in through pyodide / pyscript.

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,10 @@
     <body>
         <py-config>
         {
-            "packages": ["sketchingpy==0.1.8", "numpy", "latk"]
+            "packages": ["sketchingpy==0.1.8", "numpy", "latk"],
+            "files": {
+                "./latk_logo.latk": "latk_logo.latk"
+            }
         }
         </py-config>
 


### PR DESCRIPTION
Fix issue where the request for latk_logo is running through local resolution instead of generating a fetch in web asm by having pyodide pull the file in directly.